### PR TITLE
resolve the issue with popover spewing componentWillReceiveProps deprecation warnings

### DIFF
--- a/build/index.js
+++ b/build/index.js
@@ -1,0 +1,570 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
+
+var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
+
+var _cssVendor = require("css-vendor");
+
+var cssVendor = _interopRequireWildcard(_cssVendor);
+
+var _debug = require("debug");
+
+var _debug2 = _interopRequireDefault(_debug);
+
+var _lodash = require("lodash.throttle");
+
+var _lodash2 = _interopRequireDefault(_lodash);
+
+var _propTypes = require("prop-types");
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
+var _react = require("react");
+
+var _react2 = _interopRequireDefault(_react);
+
+var _reactDom = require("react-dom");
+
+var _reactDom2 = _interopRequireDefault(_reactDom);
+
+var _layout = require("./layout");
+
+var _layout2 = _interopRequireDefault(_layout);
+
+var _onResize = require("./on-resize");
+
+var _onResize2 = _interopRequireDefault(_onResize);
+
+var _platform = require("./platform");
+
+var _platform2 = _interopRequireDefault(_platform);
+
+var _tip = require("./tip");
+
+var _tip2 = _interopRequireDefault(_tip);
+
+var _utils = require("./utils");
+
+var _utils2 = _interopRequireDefault(_utils);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj.default = obj; return newObj; } }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
+
+function _possibleConstructorReturn(self, call) { if (!self) { throw new ReferenceError("this hasn't been initialised - super() hasn't been called"); } return call && (typeof call === "object" || typeof call === "function") ? call : self; }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
+
+var log = (0, _debug2.default)("react-popover");
+
+var supportedCSSValue = _utils2.default.clientOnly(cssVendor.supportedValue);
+
+var jsprefix = function jsprefix(x) {
+  return "" + cssVendor.prefix.js + x;
+};
+
+var cssprefix = function cssprefix(x) {
+  return "" + cssVendor.prefix.css + x;
+};
+
+var cssvalue = function cssvalue(prop, value) {
+  return supportedCSSValue(prop, value) || cssprefix(value);
+};
+
+var coreStyle = {
+  position: "absolute",
+  top: 0,
+  left: 0,
+  display: cssvalue("display", "flex")
+};
+
+var faces = {
+  above: "down",
+  right: "left",
+  below: "up",
+  left: "right"
+
+  /* Flow mappings. Each map maps the flow domain to another domain. */
+
+};var flowToTipTranslations = {
+  row: "translateY",
+  column: "translateX"
+};
+
+var flowToPopoverTranslations = {
+  row: "translateX",
+  column: "translateY"
+};
+
+var Popover = function (_React$Component) {
+  _inherits(Popover, _React$Component);
+
+  function Popover(props) {
+    _classCallCheck(this, Popover);
+
+    var _this = _possibleConstructorReturn(this, (Popover.__proto__ || Object.getPrototypeOf(Popover)).call(this, props));
+
+    _this.checkTargetReposition = function () {
+      if (_this.measureTargetBounds()) _this.resolvePopoverLayout();
+    };
+
+    _this.checkForOuterAction = function (event) {
+      var isOuterAction = !_this.containerEl.contains(event.target) && !_this.targetEl.contains(event.target);
+      if (isOuterAction) _this.props.onOuterAction(event);
+    };
+
+    _this.onTargetResize = function () {
+      log("Recalculating layout because _target_ resized!");
+      _this.measureTargetBounds();
+      _this.resolvePopoverLayout();
+    };
+
+    _this.onPopoverResize = function () {
+      log("Recalculating layout because _popover_ resized!");
+      _this.measurePopoverSize();
+      _this.resolvePopoverLayout();
+    };
+
+    _this.onFrameScroll = function () {
+      log("Recalculating layout because _frame_ scrolled!");
+      _this.measureTargetBounds();
+      _this.resolvePopoverLayout();
+    };
+
+    _this.onFrameResize = function () {
+      log("Recalculating layout because _frame_ resized!");
+      _this.measureFrameBounds();
+      _this.resolvePopoverLayout();
+    };
+
+    _this.getContainerNodeRef = function (containerEl) {
+      Object.assign(_this, { containerEl: containerEl });
+    };
+
+    _this.state = {
+      standing: "above",
+      exited: !_this.props.isOpen, // for animation-dependent rendering, should popover close/open?
+      exiting: false, // for tracking in-progress animations
+      toggle: _this.props.isOpen || false // for business logic tracking, should popover close/open?
+    };
+    return _this;
+  }
+
+  _createClass(Popover, [{
+    key: "componentDidMount",
+    value: function componentDidMount() {
+      /* Our component needs a DOM Node reference to the child so that it can be
+      measured so that we can correctly layout the popover. We do not have any
+      control over the child so cannot leverage refs. We could wrap our own
+      primitive component around the child but that could lead to breaking the
+      uses layout (e.g. the child is a flex item). Leveraging findDOMNode seems
+      to be the only functional solution, despite all the general warnings not to
+      use it. We have a legitimate use-case. */
+      // eslint-disable-next-line
+      this.targetEl = _reactDom2.default.findDOMNode(this);
+      if (this.props.isOpen) this.enter();
+    }
+  }, {
+    key: "componentDidUpdate",
+    value: function componentDidUpdate(propsPrev, statePrev) {
+      //log(`Component did update!`)
+      var willOpen = !propsPrev.isOpen && this.props.isOpen;
+      var willClose = propsPrev.isOpen && !this.props.isOpen;
+
+      if (willOpen) {
+        this.open();
+      } else if (willClose) {
+        this.close();
+      }
+
+      var didOpen = !statePrev.toggle && this.state.toggle;
+      var didClose = statePrev.toggle && !this.state.toggle;
+
+      if (didOpen) {
+        this.enter();
+      } else if (didClose) {
+        this.exit();
+      }
+    }
+  }, {
+    key: "componentWillUnmount",
+    value: function componentWillUnmount() {
+      /* If the Popover is unmounted while animating,
+      clear the animation so no setState occured */
+      this.animateExitStop();
+      /* If the Popover was never opened then then tracking
+      initialization never took place and so calling untrack
+      would be an error. Also see issue 55. */
+      if (this.hasTracked) this.untrackPopover();
+    }
+  }, {
+    key: "resolvePopoverLayout",
+    value: function resolvePopoverLayout() {
+      /* Find the optimal zone to position self. Measure the size of each zone and use the one with
+      the greatest area. */
+
+      var pickerSettings = {
+        preferPlace: this.props.preferPlace,
+        place: this.props.place
+
+        /* This is a kludge that solves a general problem very specifically for Popover.
+        The problem is subtle. When Popover positioning changes such that it resolves at
+        a different orientation, its Size will change because the Tip will toggle between
+        extending Height or Width. The general problem of course is that calculating
+        zone positioning based on current size is non-trivial if the Size can change once
+        resolved to a different zone. Infinite recursion can be triggered as we noted here:
+        https://github.com/littlebits/react-popover/issues/18. As an example of how this
+        could happen in another way: Imagine the user changes the CSS styling of the popover
+        based on whether it was `row` or `column` flow. TODO: Find a solution to generally
+        solve this problem so that the user is free to change the Popover styles in any
+        way at any time for any arbitrary trigger. There may be value in investigating the
+        http://overconstrained.io community for its general layout system via the
+        constraint-solver Cassowary. */
+      };if (this.zone) this.size[this.zone.flow === "row" ? "h" : "w"] += this.props.tipSize;
+      var zone = _layout2.default.pickZone(pickerSettings, this.frameBounds, this.targetBounds, this.size);
+      if (this.zone) this.size[this.zone.flow === "row" ? "h" : "w"] -= this.props.tipSize;
+
+      var tb = this.targetBounds;
+      this.zone = zone;
+      log("zone", zone);
+
+      this.setState({
+        standing: zone.standing
+      });
+
+      var axis = _layout2.default.axes[zone.flow];
+      log("axes", axis);
+
+      var dockingEdgeBufferLength = Math.round(getComputedStyle(this.bodyEl).borderRadius.slice(0, -2)) || 0;
+      var scrollSize = _layout2.default.El.calcScrollSize(this.frameEl);
+      scrollSize.main = scrollSize[axis.main.size];
+      scrollSize.cross = scrollSize[axis.cross.size];
+
+      /* When positioning self on the cross-axis do not exceed frame bounds. The strategy to achieve
+      this is thus: First position cross-axis self to the cross-axis-center of the the target. Then,
+      offset self by the amount that self is past the boundaries of frame. */
+      var pos = _layout2.default.calcRelPos(zone, tb, this.size);
+
+      /* Offset allows users to control the distance betweent the tip and the target. */
+      pos[axis.main.start] += this.props.offset * zone.order;
+
+      /* Constrain containerEl Position within frameEl. Try not to penetrate a visually-pleasing buffer from
+      frameEl. `frameBuffer` length is based on tipSize and its offset. */
+
+      var frameBuffer = this.props.tipSize + this.props.offset;
+      var hangingBufferLength = dockingEdgeBufferLength * 2 + this.props.tipSize * 2 + frameBuffer;
+      var frameCrossStart = this.frameBounds[axis.cross.start];
+      var frameCrossEnd = this.frameBounds[axis.cross.end];
+      var frameCrossLength = this.frameBounds[axis.cross.size];
+      var frameCrossInnerLength = frameCrossLength - frameBuffer * 2;
+      var frameCrossInnerStart = frameCrossStart + frameBuffer;
+      var frameCrossInnerEnd = frameCrossEnd - frameBuffer;
+      var popoverCrossStart = pos[axis.cross.start];
+      var popoverCrossEnd = pos[axis.cross.end];
+
+      /* If the popover dose not fit into frameCrossLength then just position it to the `frameCrossStart`.
+      popoverCrossLength` will now be forced to overflow into the `Frame` */
+      if (pos.crossLength > frameCrossLength) {
+        log("popoverCrossLength does not fit frame.");
+        pos[axis.cross.start] = 0;
+
+        /* If the `popoverCrossStart` is forced beyond some threshold of `targetCrossLength` then bound
+        it (`popoverCrossStart`). */
+      } else if (tb[axis.cross.end] < hangingBufferLength) {
+        log("popoverCrossStart cannot hang any further without losing target.");
+        pos[axis.cross.start] = tb[axis.cross.end] - hangingBufferLength;
+
+        /* checking if the cross start of the target area is within the frame and it makes sense
+        to try fitting popover into the frame. */
+      } else if (tb[axis.cross.start] > frameCrossInnerEnd) {
+        log("popoverCrossStart cannot hang any further without losing target.");
+        pos[axis.cross.start] = tb[axis.cross.start] - this.size[axis.cross.size];
+
+        /* If the `popoverCrossStart` does not fit within the inner frame (honouring buffers) then
+        just center the popover in the remaining `frameCrossLength`. */
+      } else if (pos.crossLength > frameCrossInnerLength) {
+        log("popoverCrossLength does not fit within buffered frame.");
+        pos[axis.cross.start] = (frameCrossLength - pos.crossLength) / 2;
+      } else if (popoverCrossStart < frameCrossInnerStart) {
+        log("popoverCrossStart cannot reverse without exceeding frame.");
+        pos[axis.cross.start] = frameCrossInnerStart;
+      } else if (popoverCrossEnd > frameCrossInnerEnd) {
+        log("popoverCrossEnd cannot travel without exceeding frame.");
+        pos[axis.cross.start] = pos[axis.cross.start] - (pos[axis.cross.end] - frameCrossInnerEnd);
+      }
+
+      /* So far the link position has been calculated relative to the target. To calculate the absolute
+      position we need to factor the `Frame``s scroll position */
+
+      pos[axis.cross.start] += scrollSize.cross;
+      pos[axis.main.start] += scrollSize.main;
+
+      /* Apply `flow` and `order` styles. This can impact subsequent measurements of height and width
+      of the container. When tip changes orientation position due to changes from/to `row`/`column`
+      width`/`height` will be impacted. Our layout monitoring will catch these cases and automatically
+      recalculate layout. */
+      if (this.containerEl) {
+        this.containerEl.style.flexFlow = zone.flow;
+        this.containerEl.style[jsprefix("FlexFlow")] = this.containerEl.style.flexFlow;
+      }
+      this.bodyEl.style.order = zone.order;
+      this.bodyEl.style[jsprefix("Order")] = this.bodyEl.style.order;
+
+      /* Apply Absolute Positioning. */
+
+      log("pos", pos);
+      if (this.containerEl) {
+        this.containerEl.style.top = pos.y + "px";
+        this.containerEl.style.left = pos.x + "px";
+      }
+
+      /* Calculate Tip Position */
+
+      var tipCrossPos =
+      /* Get the absolute tipCrossCenter. Tip is positioned relative to containerEl
+      but it aims at targetCenter which is positioned relative to frameEl... we
+      need to cancel the containerEl positioning so as to hit our intended position. */
+      _layout2.default.centerOfBoundsFromBounds(zone.flow, "cross", tb, pos) +
+      /* centerOfBounds does not account for scroll so we need to manually add that
+      here. */
+      scrollSize.cross -
+      /* Center tip relative to self. We do not have to calcualte half-of-tip-size since tip-size
+      specifies the length from base to tip which is half of total length already. */
+      this.props.tipSize;
+
+      if (tipCrossPos < dockingEdgeBufferLength) tipCrossPos = dockingEdgeBufferLength;else if (tipCrossPos > pos.crossLength - dockingEdgeBufferLength - this.props.tipSize * 2) {
+        tipCrossPos = pos.crossLength - dockingEdgeBufferLength - this.props.tipSize * 2;
+      }
+
+      this.tipEl.style.transform = flowToTipTranslations[zone.flow] + "(" + tipCrossPos + "px)";
+      this.tipEl.style[jsprefix("Transform")] = this.tipEl.style.transform;
+    }
+  }, {
+    key: "measurePopoverSize",
+    value: function measurePopoverSize() {
+      this.size = _layout2.default.El.calcSize(this.containerEl);
+    }
+  }, {
+    key: "measureTargetBounds",
+    value: function measureTargetBounds() {
+      var newTargetBounds = _layout2.default.El.calcBounds(this.targetEl);
+
+      if (this.targetBounds && _layout2.default.equalCoords(this.targetBounds, newTargetBounds)) {
+        return false;
+      }
+
+      this.targetBounds = newTargetBounds;
+      return true;
+    }
+  }, {
+    key: "open",
+    value: function open() {
+      if (this.state.exiting) this.animateExitStop();
+      this.setState({ toggle: true, exited: false });
+    }
+  }, {
+    key: "close",
+    value: function close() {
+      this.setState({ toggle: false });
+    }
+  }, {
+    key: "enter",
+    value: function enter() {
+      if (_platform2.default.isServer) return;
+      log("enter!");
+      this.trackPopover();
+      this.animateEnter();
+    }
+  }, {
+    key: "exit",
+    value: function exit() {
+      log("exit!");
+      this.animateExit();
+      this.untrackPopover();
+    }
+  }, {
+    key: "animateExitStop",
+    value: function animateExitStop() {
+      clearTimeout(this.exitingAnimationTimer1);
+      clearTimeout(this.exitingAnimationTimer2);
+      this.setState({ exiting: false });
+    }
+  }, {
+    key: "animateExit",
+    value: function animateExit() {
+      var _this2 = this;
+
+      this.setState({ exiting: true });
+      this.exitingAnimationTimer2 = setTimeout(function () {
+        setTimeout(function () {
+          if (_this2.containerEl) {
+            _this2.containerEl.style.transform = flowToPopoverTranslations[_this2.zone.flow] + "(" + _this2.zone.order * 50 + "px)";
+            _this2.containerEl.style.opacity = "0";
+          }
+        }, 0);
+      }, 0);
+
+      this.exitingAnimationTimer1 = setTimeout(function () {
+        _this2.setState({ exited: true, exiting: false });
+      }, this.props.enterExitTransitionDurationMs);
+    }
+  }, {
+    key: "animateEnter",
+    value: function animateEnter() {
+      /* Prepare `entering` style so that we can then animate it toward `entered`. */
+
+      this.containerEl.style.transform = flowToPopoverTranslations[this.zone.flow] + "(" + this.zone.order * 50 + "px)";
+      this.containerEl.style[jsprefix("Transform")] = this.containerEl.style.transform;
+      this.containerEl.style.opacity = "0";
+
+      /* After initial layout apply transition animations. */
+      /* Hack: http://stackoverflow.com/questions/3485365/how-can-i-force-webkit-to-redraw-repaint-to-propagate-style-changes */
+      this.containerEl.offsetHeight;
+
+      /* If enterExitTransitionDurationMs is falsy, tip animation should be also disabled */
+      if (this.props.enterExitTransitionDurationMs) {
+        this.tipEl.style.transition = "transform 150ms ease-in";
+        this.tipEl.style[jsprefix("Transition")] = cssprefix("transform") + " 150ms ease-in";
+      }
+      this.containerEl.style.transitionProperty = "top, left, opacity, transform";
+      this.containerEl.style.transitionDuration = this.props.enterExitTransitionDurationMs + "ms";
+      this.containerEl.style.transitionTimingFunction = "cubic-bezier(0.230, 1.000, 0.320, 1.000)";
+      this.containerEl.style.opacity = "1";
+      this.containerEl.style.transform = "translateY(0)";
+      this.containerEl.style[jsprefix("Transform")] = this.containerEl.style.transform;
+    }
+  }, {
+    key: "trackPopover",
+    value: function trackPopover() {
+      var minScrollRefreshIntervalMs = 200;
+      var minResizeRefreshIntervalMs = 200;
+
+      /* Get references to DOM elements. */
+
+      this.bodyEl = this.containerEl.querySelector(".Popover-body");
+      this.tipEl = this.containerEl.querySelector(".Popover-tip");
+
+      /* Note: frame is hardcoded to window now but we think it will
+      be a nice feature in the future to allow other frames to be used
+      such as local elements that further constrain the popover`s world. */
+
+      this.frameEl = _platform2.default.window;
+      this.hasTracked = true;
+
+      /* Set a general interval for checking if target position changed. There is no way
+      to know this information without polling. */
+      if (this.props.refreshIntervalMs) {
+        this.checkLayoutInterval = setInterval(this.checkTargetReposition, this.props.refreshIntervalMs);
+      }
+
+      /* Watch for boundary changes in all deps, and when one of them changes, recalculate layout.
+      This layout monitoring must be bound immediately because a layout recalculation can recursively
+      cause a change in boundaries. So if we did a one-time force-layout before watching boundaries
+      our final position calculations could be wrong. See comments in resolver function for details
+      about which parts can trigger recursive recalculation. */
+
+      this.onFrameScroll = (0, _lodash2.default)(this.onFrameScroll, minScrollRefreshIntervalMs);
+      this.onFrameResize = (0, _lodash2.default)(this.onFrameResize, minResizeRefreshIntervalMs);
+      this.onPopoverResize = (0, _lodash2.default)(this.onPopoverResize, minResizeRefreshIntervalMs);
+      this.onTargetResize = (0, _lodash2.default)(this.onTargetResize, minResizeRefreshIntervalMs);
+
+      this.frameEl.addEventListener("scroll", this.onFrameScroll);
+      _onResize2.default.on(this.frameEl, this.onFrameResize);
+      _onResize2.default.on(this.containerEl, this.onPopoverResize);
+      _onResize2.default.on(this.targetEl, this.onTargetResize);
+
+      /* Track user actions on the page. Anything that occurs _outside_ the Popover boundaries
+      should close the Popover. */
+
+      _platform2.default.document.addEventListener("mousedown", this.checkForOuterAction);
+      _platform2.default.document.addEventListener("touchstart", this.checkForOuterAction);
+
+      /* Kickstart layout at first boot. */
+
+      this.measurePopoverSize();
+      this.measureFrameBounds();
+      this.measureTargetBounds();
+      this.resolvePopoverLayout();
+    }
+  }, {
+    key: "untrackPopover",
+    value: function untrackPopover() {
+      clearInterval(this.checkLayoutInterval);
+      this.frameEl.removeEventListener("scroll", this.onFrameScroll);
+      _onResize2.default.off(this.frameEl, this.onFrameResize);
+      _onResize2.default.off(this.containerEl, this.onPopoverResize);
+      _onResize2.default.off(this.targetEl, this.onTargetResize);
+      _platform2.default.document.removeEventListener("mousedown", this.checkForOuterAction);
+      _platform2.default.document.removeEventListener("touchstart", this.checkForOuterAction);
+      this.hasTracked = false;
+    }
+  }, {
+    key: "measureFrameBounds",
+    value: function measureFrameBounds() {
+      this.frameBounds = _layout2.default.El.calcBounds(this.frameEl);
+    }
+  }, {
+    key: "render",
+    value: function render() {
+      var _props = this.props,
+          _props$className = _props.className,
+          className = _props$className === undefined ? "" : _props$className,
+          _props$style = _props.style,
+          style = _props$style === undefined ? {} : _props$style,
+          tipSize = _props.tipSize;
+      var standing = this.state.standing;
+
+
+      var popoverProps = {
+        className: "Popover Popover-" + standing + " " + className,
+        style: _extends({}, coreStyle, style)
+      };
+
+      var popover = this.state.exited ? null : _react2.default.createElement(
+        "div",
+        _extends({ ref: this.getContainerNodeRef }, popoverProps),
+        _react2.default.createElement("div", { className: "Popover-body", children: this.props.body }),
+        _react2.default.createElement(_tip2.default, { direction: faces[standing], size: tipSize })
+      );
+      return [this.props.children, _platform2.default.isClient && _reactDom2.default.createPortal(popover, this.props.appendTarget)];
+    }
+  }]);
+
+  return Popover;
+}(_react2.default.Component);
+
+Popover.propTypes = {
+  body: _propTypes2.default.node.isRequired,
+  children: _propTypes2.default.element.isRequired,
+  appendTarget: _propTypes2.default.object,
+  className: _propTypes2.default.string,
+  enterExitTransitionDurationMs: _propTypes2.default.number,
+  isOpen: _propTypes2.default.bool,
+  offset: _propTypes2.default.number,
+  place: _propTypes2.default.oneOf(_layout2.default.validTypeValues),
+  preferPlace: _propTypes2.default.oneOf(_layout2.default.validTypeValues),
+  refreshIntervalMs: _propTypes2.default.oneOfType([_propTypes2.default.number, _propTypes2.default.bool]),
+  style: _propTypes2.default.object,
+  tipSize: _propTypes2.default.number,
+  onOuterAction: _propTypes2.default.func
+};
+Popover.defaultProps = {
+  tipSize: 7,
+  preferPlace: null,
+  place: null,
+  offset: 4,
+  isOpen: false,
+  onOuterAction: _utils2.default.noop,
+  enterExitTransitionDurationMs: 500,
+  children: null,
+  refreshIntervalMs: 200,
+  appendTarget: _platform2.default.isClient ? _platform2.default.document.body : null
+};
+exports.default = Popover;

--- a/build/layout.js
+++ b/build/layout.js
@@ -1,0 +1,268 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.equalCoords = exports.doesFitWithin = exports.centerOfBoundsFromBounds = exports.centerOfBounds = exports.centerOfSize = exports.axes = exports.pickZone = exports.place = exports.calcRelPos = exports.validTypeValues = exports.types = exports.El = undefined;
+
+var _platform = require("./platform");
+
+var _utils = require("./utils");
+
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
+/* Axes System
+
+This allows us to at-will work in a different orientation
+without having to manually keep track of knowing if we should be using
+x or y positions. */
+
+var axes = {
+  row: {},
+  column: {}
+};
+
+axes.row.main = {
+  start: "x",
+  end: "x2",
+  size: "w"
+};
+axes.row.cross = {
+  start: "y",
+  end: "y2",
+  size: "h"
+};
+axes.column.main = axes.row.cross;
+axes.column.cross = axes.row.main;
+
+var types = [{ name: "side", values: ["start", "end"] }, { name: "standing", values: ["above", "right", "below", "left"] }, { name: "flow", values: ["column", "row"] }];
+
+var validTypeValues = types.reduce(function (xs, _ref) {
+  var values = _ref.values;
+  return xs.concat(values);
+}, []);
+
+var centerOfSize = function centerOfSize(flow, axis, size) {
+  return size[axes[flow][axis].size] / 2;
+};
+
+var centerOfBounds = function centerOfBounds(flow, axis, bounds) {
+  return bounds[axes[flow][axis].start] + bounds[axes[flow][axis].size] / 2;
+};
+
+var centerOfBoundsFromBounds = function centerOfBoundsFromBounds(flow, axis, boundsTo, boundsFrom) {
+  return centerOfBounds(flow, axis, boundsTo) - boundsFrom[axes[flow][axis].start];
+};
+
+var place = function place(flow, axis, align, bounds, size) {
+  var axisProps = axes[flow][axis];
+  return align === "center" ? centerOfBounds(flow, axis, bounds) - centerOfSize(flow, axis, size) : align === "end" ? bounds[axisProps.end] : align === "start" ? /* DOM rendering unfolds leftward. Therefore if the slave is positioned before
+                                                                                                                                                                  the master then the slave`s position must in addition be pulled back
+                                                                                                                                                                  by its [the slave`s] own length. */
+  bounds[axisProps.start] - size[axisProps.size] : null;
+};
+
+/* Element Layout Queries */
+
+var El = {};
+
+El.calcBounds = function (el) {
+  if (el === _platform.window) {
+    return {
+      x: 0,
+      y: 0,
+      x2: el.innerWidth,
+      y2: el.innerHeight,
+      w: el.innerWidth,
+      h: el.innerHeight
+    };
+  }
+
+  var b = el.getBoundingClientRect();
+
+  return {
+    x: b.left,
+    y: b.top,
+    x2: b.right,
+    y2: b.bottom,
+    w: b.right - b.left,
+    h: b.bottom - b.top
+  };
+};
+
+El.calcSize = function (el) {
+  return el === _platform.window ? { w: el.innerWidth, h: el.innerHeight } : { w: el.offsetWidth, h: el.offsetHeight };
+};
+
+El.calcScrollSize = function (el) {
+  return el === _platform.window ? {
+    w: el.scrollX || el.pageXOffset,
+    h: el.scrollY || el.pageYOffset
+  } : { w: el.scrollLeft, h: el.scrollTop
+
+    /* Misc Utilities */
+
+  };
+};var getPreferenceType = function getPreferenceType(preference) {
+  return types.reduce(function (found, type) {
+    return found ? found : type.values.indexOf(preference) !== -1 ? type.name : null;
+  }, null);
+};
+
+/* Dimension Fit Checks */
+
+var fitWithinChecker = function fitWithinChecker(dimension) {
+  return function (domainSize, itemSize) {
+    return domainSize[dimension] >= itemSize[dimension];
+  };
+};
+
+var doesWidthFitWithin = fitWithinChecker("w");
+var doesHeightFitWithin = fitWithinChecker("h");
+
+var doesFitWithin = function doesFitWithin(domainSize, itemSize) {
+  return doesWidthFitWithin(domainSize, itemSize) && doesHeightFitWithin(domainSize, itemSize);
+};
+
+/* Errors */
+
+var createPreferenceError = function createPreferenceError(givenValue) {
+  return new Error("The given layout placement of \"" + givenValue + "\" is not a valid choice. Valid choices are: " + validTypeValues.join(" | ") + ".");
+};
+
+/* Algorithm for picking the best fitting zone for popover. The current technique will loop through all zones picking the last one that fits.
+In the case that none fit we should pick the least-not-fitting zone. */
+
+var pickZone = function pickZone(opts, frameBounds, targetBounds, size) {
+  var t = targetBounds;
+  var f = frameBounds;
+  var zones = [{
+    side: "start",
+    standing: "above",
+    flow: "column",
+    order: -1,
+    w: f.x2,
+    h: t.y
+  }, {
+    side: "end",
+    standing: "right",
+    flow: "row",
+    order: 1,
+    w: f.x2 - t.x2,
+    h: f.y2
+  }, {
+    side: "end",
+    standing: "below",
+    flow: "column",
+    order: 1,
+    w: f.x2,
+    h: f.y2 - t.y2
+  }, {
+    side: "start",
+    standing: "left",
+    flow: "row",
+    order: -1,
+    w: t.x,
+    h: f.y2
+  }];
+
+  /* Order the zones by the amount of popup that would be cut out if that zone is used.
+     The first one in the array is the one that cuts the least amount.
+      const area = size.w * size.h  // Popup area is constant and it does not change the order
+  */
+  zones.forEach(function (z) {
+    // TODO Update to satisfy linter
+    // eslint-disable-next-line no-param-reassign
+    z.cutOff =
+    /* area */-Math.max(0, Math.min(z.w, size.w)) * Math.max(0, Math.min(z.h, size.h));
+  });
+  zones.sort(function (a, b) {
+    return a.cutOff - b.cutOff;
+  });
+
+  var availZones = zones.filter(function (zone) {
+    return doesFitWithin(zone, size);
+  });
+
+  /* If a place is required pick it from the available zones if possible. */
+
+  if (opts.place) {
+    var type = getPreferenceType(opts.place);
+    if (!type) throw createPreferenceError(opts.place);
+    var finder = function finder(z) {
+      return z[type] === opts.place;
+    };
+    return (0, _utils.find)(finder, availZones) || (0, _utils.find)(finder, zones);
+  }
+
+  /* If the preferred side is part of the available zones, use that otherwise
+  pick the largest available zone. If there are no available zones, pick the
+  largest zone. */
+
+  if (opts.preferPlace) {
+    var preferenceType = getPreferenceType(opts.preferPlace);
+    if (!preferenceType) throw createPreferenceError(opts.preferPlace);
+
+    // Try to fit first in zone where the pop up fit completely
+    var preferredAvailZones = availZones.filter(function (zone) {
+      return zone[preferenceType] === opts.preferPlace;
+    });
+    if (preferredAvailZones.length) return preferredAvailZones[0];
+
+    // If there are not areas where the pop up fit completely, it uses the preferred ones
+    // in order from the one the fit better
+    var preferredZones = zones.filter(function (zone) {
+      return zone[preferenceType] === opts.preferPlace;
+    });
+    if (!availZones.length && preferredZones.length) return preferredZones[0];
+  }
+
+  // Return a zone that fit completely or the one that fit the best
+  return availZones.length ? availZones[0] : zones[0];
+};
+
+/* TODO Document this. */
+
+var calcRelPos = function calcRelPos(zone, masterBounds, slaveSize) {
+  var _ref2;
+
+  var _axes$zone$flow = axes[zone.flow],
+      main = _axes$zone$flow.main,
+      cross = _axes$zone$flow.cross;
+  /* TODO: The slave is hard-coded to align cross-center with master. */
+
+  var crossAlign = "center";
+  var mainStart = place(zone.flow, "main", zone.side, masterBounds, slaveSize);
+  var mainSize = slaveSize[main.size];
+  var crossStart = place(zone.flow, "cross", crossAlign, masterBounds, slaveSize);
+  var crossSize = slaveSize[cross.size];
+
+  return _ref2 = {}, _defineProperty(_ref2, main.start, mainStart), _defineProperty(_ref2, "mainLength", mainSize), _defineProperty(_ref2, main.end, mainStart + mainSize), _defineProperty(_ref2, cross.start, crossStart), _defineProperty(_ref2, "crossLength", crossSize), _defineProperty(_ref2, cross.end, crossStart + crossSize), _ref2;
+};
+
+exports.default = {
+  El: El,
+  types: types,
+  validTypeValues: validTypeValues,
+  calcRelPos: calcRelPos,
+  place: place,
+  pickZone: pickZone,
+  axes: axes,
+  centerOfSize: centerOfSize,
+  centerOfBounds: centerOfBounds,
+  centerOfBoundsFromBounds: centerOfBoundsFromBounds,
+  doesFitWithin: doesFitWithin,
+  equalCoords: _utils.equalRecords
+};
+exports.El = El;
+exports.types = types;
+exports.validTypeValues = validTypeValues;
+exports.calcRelPos = calcRelPos;
+exports.place = place;
+exports.pickZone = pickZone;
+exports.axes = axes;
+exports.centerOfSize = centerOfSize;
+exports.centerOfBounds = centerOfBounds;
+exports.centerOfBoundsFromBounds = centerOfBoundsFromBounds;
+exports.doesFitWithin = doesFitWithin;
+exports.equalCoords = _utils.equalRecords;

--- a/build/on-resize.js
+++ b/build/on-resize.js
@@ -1,0 +1,120 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.removeEventListener = exports.addEventListener = exports.off = exports.on = undefined;
+
+var _platform = require("./platform");
+
+var _utils = require("./utils");
+
+/* eslint no-param-reassign: 0 */
+
+var requestAnimationFrame = _platform.isServer ? _utils.noop : _platform.window.requestAnimationFrame || _platform.window.mozRequestAnimationFrame || _platform.window.webkitRequestAnimationFrame || function (fn) {
+  _platform.window.setTimeout(fn, 20);
+};
+
+var cancelAnimationFrame = _platform.isServer ? _utils.noop : _platform.window.cancelAnimationFrame || _platform.window.mozCancelAnimationFrame || _platform.window.webkitCancelAnimationFrame || _platform.window.clearTimeout;
+
+var isIE = _platform.isServer ? false : navigator.userAgent.match(/Trident/);
+
+var namespace = "__resizeDetector__";
+
+var uninitialize = function uninitialize(el) {
+  el[namespace].destroy();
+  el[namespace] = undefined;
+};
+
+var createElementHack = function createElementHack() {
+  var el = document.createElement("object");
+  el.className = "resize-sensor";
+  el.setAttribute("style", "display: block; position: absolute; top: 0; left: 0; height: 100%; width: 100%; overflow: hidden; pointer-events: none; z-index: -1;");
+  el.setAttribute("class", "resize-sensor");
+  el.setAttribute("tabindex", "-1");
+  el.type = "text/html";
+  el.data = "about:blank";
+  return el;
+};
+
+var initialize = function initialize(el) {
+  var detector = el[namespace] = {};
+  detector.listeners = [];
+
+  var onResize = function onResize(e) {
+    /* Keep in mind e.target could be el OR objEl. In this current implementation we don't seem to need to know this but its important
+    to not forget e.g. in some future refactoring scenario. */
+    if (detector.resizeRAF) cancelAnimationFrame(detector.resizeRAF);
+    detector.resizeRAF = requestAnimationFrame(function () {
+      detector.listeners.forEach(function (fn) {
+        fn(e);
+      });
+    });
+  };
+
+  if (isIE) {
+    /* We do not support ie8 and below (or ie9 in compat mode).
+    Therefore there is no presence of `attachEvent` here. */
+    el.addEventListener("onresize", onResize);
+    detector.destroy = function () {
+      el.removeEventListener("onresize", onResize);
+    };
+  } else {
+    if (getComputedStyle(el).position === "static") {
+      detector.elWasStaticPosition = true;
+      el.style.position = "relative";
+    }
+    var objEl = createElementHack();
+    objEl.onload = function () /* event */{
+      this.contentDocument.defaultView.addEventListener("resize", onResize);
+    };
+    detector.destroy = function () {
+      if (detector.elWasStaticPosition) el.style.position = "";
+      if (el.contains(objEl)) {
+        // Event handlers will be automatically removed.
+        // http://stackoverflow.com/questions/12528049/if-a-dom-element-is-removed-are-its-listeners-also-removed-from-memory
+        el.removeChild(objEl);
+      }
+    };
+
+    el.appendChild(objEl);
+  }
+};
+
+var on = function on(el, fn) {
+  /* Window object natively publishes resize events. We handle it as a
+  special case here so that users do not have to think about two APIs. */
+
+  if (el === _platform.window) {
+    _platform.window.addEventListener("resize", fn);
+    return;
+  }
+
+  /* Not caching namespace read here beacuse not guaranteed that its available. */
+
+  if (!el[namespace]) initialize(el);
+  el[namespace].listeners.push(fn);
+};
+
+var off = function off(el, fn) {
+  if (el === _platform.window) {
+    _platform.window.removeEventListener("resize", fn);
+    return;
+  }
+  var detector = el[namespace];
+  if (!detector) return;
+  var i = detector.listeners.indexOf(fn);
+  if (i !== -1) detector.listeners.splice(i, 1);
+  if (!detector.listeners.length) uninitialize(el);
+};
+
+exports.default = {
+  on: on,
+  off: off,
+  addEventListener: on,
+  removeEventListener: off
+};
+exports.on = on;
+exports.off = off;
+exports.addEventListener = on;
+exports.removeEventListener = off;

--- a/build/platform.js
+++ b/build/platform.js
@@ -1,0 +1,20 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+var isServer = typeof window === "undefined";
+var isClient = !isServer;
+var WINDOW = isClient ? window : null;
+var DOCUMENT = isClient ? document : null;
+
+exports.default = {
+  isServer: isServer,
+  isClient: isClient,
+  window: WINDOW,
+  document: DOCUMENT
+};
+exports.isServer = isServer;
+exports.isClient = isClient;
+exports.window = WINDOW;
+exports.document = DOCUMENT;

--- a/build/tip.js
+++ b/build/tip.js
@@ -1,0 +1,34 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+
+var _react = require("react");
+
+var _react2 = _interopRequireDefault(_react);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var Tip = function Tip(props) {
+  var direction = props.direction;
+
+  var size = props.size || 24;
+  var isPortrait = direction === "up" || direction === "down";
+  var mainLength = size;
+  var crossLength = size * 2;
+  var points = direction === "up" ? "0," + mainLength + " " + mainLength + ",0, " + crossLength + "," + mainLength : direction === "down" ? "0,0 " + mainLength + "," + mainLength + ", " + crossLength + ",0" : direction === "left" ? mainLength + ",0 0," + mainLength + ", " + mainLength + "," + crossLength : "0,0 " + mainLength + "," + mainLength + ", 0," + crossLength;
+  var svgProps = {
+    className: "Popover-tip",
+    width: isPortrait ? crossLength : mainLength,
+    height: isPortrait ? mainLength : crossLength
+  };
+
+  return _react2.default.createElement(
+    "svg",
+    svgProps,
+    _react2.default.createElement("polygon", { className: "Popover-tipShape", points: points })
+  );
+};
+
+exports.default = Tip;

--- a/build/utils.js
+++ b/build/utils.js
@@ -1,0 +1,39 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.clientOnly = exports.noop = exports.equalRecords = exports.find = undefined;
+
+var _platform = require("./platform");
+
+var find = function find(f, xs) {
+  return xs.reduce(function (b, x) {
+    return b ? b : f(x) ? x : null;
+  }, null);
+};
+
+var equalRecords = function equalRecords(o1, o2) {
+  for (var key in o1) {
+    if (o1[key] !== o2[key]) return false;
+  }return true;
+};
+
+var noop = function noop() {
+  return undefined;
+};
+
+var clientOnly = function clientOnly(f) {
+  return _platform.isClient ? f : noop;
+};
+
+exports.default = {
+  find: find,
+  equalRecords: equalRecords,
+  noop: noop,
+  clientOnly: clientOnly
+};
+exports.find = find;
+exports.equalRecords = equalRecords;
+exports.noop = noop;
+exports.clientOnly = clientOnly;

--- a/source/index.js
+++ b/source/index.js
@@ -98,15 +98,22 @@ class Popover extends React.Component {
   }
   componentDidUpdate(propsPrev, statePrev) {
     //log(`Component did update!`)
+    const willOpen = !propsPrev.isOpen && this.props.isOpen
+    const willClose = propsPrev.isOpen && !this.props.isOpen
+
+    if (willOpen) {
+      this.open()
+    } else if (willClose) {
+      this.close()
+    }
+
     const didOpen = !statePrev.toggle && this.state.toggle
     const didClose = statePrev.toggle && !this.state.toggle
 
     if (didOpen) {
-      this.open() // todo: remove
       this.enter()
     }
     else if (didClose) {
-      this.close() // todo: remove
       this.exit()
     }
   }


### PR DESCRIPTION
There is a PR up at https://github.com/littlebits/react-popover/pull/208, but it doesn't actually work AFAICT (tested in their own storybook locally). The problem is that the check for state change isn't enough, as it creates a chicken and egg problem with when the containerEl field is set on the popover ref - the state doesn't change initially.

The state can't be assumed to change always, so go back to checking props for opening/closing, the way the component worked previously (except do it in componentDidUpdate to prevent the warning spew)